### PR TITLE
Ignore Next.js preview channel in Dependabot (TS7 regression)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,11 @@ updates:
       - dependency-name: "@types/node"
         update-types:
           - "version-update:semver-major"
+      # Next.js @preview cuts are ad-hoc snapshots from older canaries, then
+      # canary keeps advancing. Semver ranks "preview" > "canary", so Dependabot
+      # treats stale preview builds as upgrades (e.g. canary.83 → preview.5) and
+      # drops TypeScript 7 support (experimental.useTypeScriptCli from #95639).
+      # Stay on canary (or stable) until a preview cut includes that fix.
+      - dependency-name: "next"
+        versions:
+          - ">=16.3.0-preview.0 <16.3.0"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Review of open Dependabot PR [#343](https://github.com/jeasmith/wheeloftim/pull/343) and CI/security tooling.

### Dependabot #343 — do not merge

`16.3.0-preview.5` is **not** newer than `16.3.0-canary.83`:

| | preview.5 | canary.83 (main) |
|---|---|---|
| Published | 2026-06-25 | 2026-07-10 |
| Cut from | ~canary.66 era | latest canary |
| TS7 CLI (`useTypeScriptCli`) | missing | present (#95639) |

Semver ranks the prerelease tag `preview` above `canary`, so Dependabot reports a patch “upgrade.” CI on #343 fails because Next misdetects TypeScript 7 as missing and rejects `experimental.useTypeScriptCli` — the exact problem #342 fixed by moving to canary.83.

This PR ignores the `16.3.0-preview.*` line in Dependabot so that trap cannot recur while we stay on canary.

**Recommendation:** close #343.

### StepSecurity #328 — low incremental value; close

Already on main from earlier StepSecurity work (#327 and prior):

- SHA-pinned Actions
- `step-security/harden-runner` on CI + CodeQL (**audit** mode only — logs egress, does not block)
- CodeQL Advanced Security (`security-and-quality` for JS/TS + Actions)
- Dependabot for npm + GitHub Actions (with grouping)
- Recent vulnerability overrides (`undici` / `vite` / `esbuild`)

#328 would add Dependency Review, OpenSSF Scorecard, and a pre-commit config (gitleaks + eslint + whitespace). For this app (public, fully client-side, localStorage only, no secrets/backend):

| Proposed | Overlap / gap |
|---|---|
| Dependency Review | Mostly overlaps Dependabot alerts + version PRs; useful only if made a **required** check |
| Scorecard | Supply-chain score/badge for a library ecosystem — little practical gain for a tiny personal app already running CodeQL |
| pre-commit gitleaks/eslint | Repo has no ESLint setup; hooks are outdated (eslint v8, gitleaks v8.16.3) and unused unless developers install pre-commit |

**Verdict:** existing CodeQL + Dependabot + pinned Actions already match the threat model. Harden-runner in audit mode is mostly telemetry; promoting to `block` only pays off if you invest in an allowlist. Close #328 unless you specifically want Scorecard badges or a required Dependency Review gate.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-224d6749-c107-4a41-8231-17aa423e0dc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-224d6749-c107-4a41-8231-17aa423e0dc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to handle specified Next.js preview versions appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->